### PR TITLE
Fix Velocity error in Listener.

### DIFF
--- a/velocity/src/main/java/com/github/gerolndnr/connectionguard/velocity/listener/ConnectionGuardVelocityListener.java
+++ b/velocity/src/main/java/com/github/gerolndnr/connectionguard/velocity/listener/ConnectionGuardVelocityListener.java
@@ -22,7 +22,7 @@ public class ConnectionGuardVelocityListener {
     @Subscribe
     public EventTask onPreLogin(PreLoginEvent loginEvent) {
         String ipAddress = loginEvent.getConnection().getRemoteAddress().getHostString();
-        String playerUuid = loginEvent.getUniqueId().toString();
+        String playerUuid = (loginEvent.getUniqueId() != null) ? loginEvent.getUniqueId().toString() : "";
         String playerUsername = loginEvent.getUsername();
 
         CompletableFuture<VpnResult> vpnResultFuture;


### PR DESCRIPTION
The [PreLoginEvent (jd.papermc.io)](https://jd.papermc.io/velocity/3.4.0/com/velocitypowered/api/event/connection/PreLoginEvent.html) gives always `null` the UUID for clients versions under than 1.19.2 and will be available in their totally from 1.20.2+ client version to receive a value.

This fixes https://github.com/gerolndnr/connection-guard/issues/27 about `.toString()` method when UUID it's null, with only returning `""` when occurs.