### PR TITLE
prevent PreLoginEvent overwrite by removing explicit allowed result

### DIFF
--- a/velocity/src/main/java/com/github/gerolndnr/connectionguard/velocity/listener/ConnectionGuardVelocityListener.java
+++ b/velocity/src/main/java/com/github/gerolndnr/connectionguard/velocity/listener/ConnectionGuardVelocityListener.java
@@ -187,7 +187,7 @@ public class ConnectionGuardVelocityListener {
                 }
 
                 // loginEvent.setResult(ResultedEvent.ComponentResult.allowed());
-                loginEvent.setResult(PreLoginEvent.PreLoginComponentResult.allowed());
+                // loginEvent.setResult(PreLoginEvent.PreLoginComponentResult.allowed());
             }
         });
     }


### PR DESCRIPTION
Calling `setResult(allowed())` on clean IPs blindly overwrites prior event states (such as Floodgate's `forceOfflineMode()`), which breaks Bedrock connections on hybrid servers.

Removed the explicit `allowed()` call. Since Velocity defaults to an `allowed` state, the plugin now only modifies the result when actively denying a VPN connection. This allows it to act as a safe filter without erasing upstream plugin modifications.

this fixes #31 

Known Limitation:
Permission-based VPN exemptions (via LuckPerms) for Bedrock players currently do not work. During the `PreLoginEvent`, Geyser uses an different UUID before Floodgate maps the JAVA profile. Consequently, LuckPerms receives an unmapped UUID and the bypass check fails.